### PR TITLE
LB Script to add new column profile_visibility to the freelancers table

### DIFF
--- a/db/changelog/profile_management/JMK_98.xml
+++ b/db/changelog/profile_management/JMK_98.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="JMK_98_01_Create_Enum_Profile_Visibility" author="Kirandeep Kaur">
+        <sql>
+            CREATE TYPE profile_visibility AS ENUM ('PUBLIC', 'PRIVATE');
+        </sql>
+    </changeSet>
+
+    <changeSet id="JMK_98_02_Add_Profile_Visibility_Column" author="Kirandeep Kaur">
+        <addColumn tableName="freelancers">
+            <column name="profile_visibility" type="profile_visibility" />
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/dbchangelog.xml
+++ b/dbchangelog.xml
@@ -15,5 +15,6 @@
     <include file="db/changelog/job_posting/JMK_72.xml"/>
     <include file="db/changelog/job_posting/JMK_91.xml"/>
     <include file="db/changelog/profile_management/JMK_95.xml"/>
+    <include file="db/changelog/profile_management/JMK_98.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
- Created a new ENUM type `profile_visibility` with possible values: `'PUBLIC'`, `'PRIVATE'`.
- Added `profile_visibility` column to the `freelancers` table using the above ENUM.
