### PR TITLE
JMK_110: LB script to create table proposal_question_answer

### DIFF
--- a/db/changelog/proposal/JMK_110.xml
+++ b/db/changelog/proposal/JMK_110.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="JMK_110_01_Create_Proposal_Question_Answer_Table" author="Ansh Preet Kaur">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="proposal_question_answer"/>
+            </not>
+        </preConditions>
+
+        <createTable tableName="proposal_question_answer">
+            <column name="answer_id" type="BIGSERIAL">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+
+            <column name="proposal_id" type="BIGINT">
+                <constraints nullable="false"
+                             foreignKeyName="fk_answer_proposal"
+                             referencedTableName="proposals"
+                             referencedColumnNames="proposal_id"/>
+            </column>
+
+            <column name="question_id" type="BIGINT">
+                <constraints nullable="false"
+                             foreignKeyName="fk_answer_question"
+                             referencedTableName="job_posting_questions"
+                             referencedColumnNames="question_id"/>
+            </column>
+
+            <column name="answer" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="created_at" type="TIMESTAMP"/>
+            <column name="updated_at" type="TIMESTAMP"/>
+        </createTable>
+
+        <addUniqueConstraint
+                tableName="proposal_question_answer"
+                columnNames="proposal_id, question_id"
+                constraintName="uq_proposal_question_pair"/>
+
+        <rollback>
+            <dropTable tableName="proposal_question_answer"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/dbchangelog.xml
+++ b/dbchangelog.xml
@@ -17,5 +17,6 @@
     <include file="db/changelog/profile_management/JMK_95.xml"/>
     <include file="db/changelog/profile_management/JMK_98.xml"/>
     <include file="db/changelog/job_posting/JMK_89.xml"/>
+    <include file="db/changelog/proposal/JMK_110.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
[JMK_110](https://punjabskillsbank.atlassian.net/jira/software/projects/JMK/boards/4?selectedIssue=JMK-110)
Added a new table proposal_question_answer to store answers submitted by freelancers for the optional questions defined in a job post. 

**Table fields:**
- answer_id (BIGSERIAL)
- proposal_id (BIGINT)
- question_id (BIGINT)
- answer (TEXT)
- created_at (TIMESTAMP)
- updated_at (TIMESTAMP)

Also added a unique constraint on the combination of proposal_id and question_id to prevent duplicate answers for the same question in a single proposal.

**Relations:**
- proposal to proposal_question_answer ->One-to-Many
One proposal can have many answers 
- job_posting_question to proposal_question_answer ->One-to-Many
On job posting question can have many answers across different proposals